### PR TITLE
chore: update k8s_manifests_base_dir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,12 +3,12 @@ k8s_manifests: []
 # - monitoring/prometheus
 # - dir: monitoring/grafana-configmap
 #   lookup_type: 'file'
-k8s_manifests_base_dir: ''
+k8s_manifests_base_dir: '{{playbook_dir}}/vars/k8s-cluster/k8s-manifests/'
 k8s_manifests_state: present
 k8s_force: false
 
 k8s_kubeconfig: ~/.kube/config
 
 k8s_resource_namespace: ''
-k8s_manage_namespace: true
-k8s_no_log: true
+k8s_manage_namespace: false
+k8s_no_log: false


### PR DESCRIPTION
- Change the k8s manifests default path.
- Disable the namespace creation.
- make it verbose so we can see kubernetes output log.